### PR TITLE
Add dev tooling and linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,21 @@
+linters:
+
+  enable:
+    - goimports
+    - misspell
+    - revive
+    - noctx
+    - bodyclose
+    - wastedassign
+    - sqlclosecheck
+    - usetesting
+    - tparallel
+    - paralleltest
+    - gocritic
+    - nilnil
+    - nilerr
+    - exhaustive
+
+run:
+  timeout: 5m
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "mise.configureExtensionsAutomatically": false,
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,15 +3,16 @@ package main
 import (
 	"context"
 	"errors"
-	"github.com/tlscert/backend/internal/api"
-	"github.com/tlscert/backend/internal/kubernetes"
-	"github.com/tlscert/backend/internal/manager"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/tlscert/backend/internal/api"
+	"github.com/tlscert/backend/internal/kubernetes"
+	"github.com/tlscert/backend/internal/manager"
 )
 
 func main() {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/tlscert/backend/internal/manager"
@@ -35,14 +36,24 @@ func (s *Server) handleGetCertificate(w http.ResponseWriter, r *http.Request) {
 	certificate, err := s.cm.GetCertificate(r.Context())
 
 	if err != nil {
+		log.Printf("error getting certificate: %v", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		err := json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": err.Error(),
 		})
+		if err != nil {
+			log.Printf("error encoding error: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(certificate)
+	if err := json.NewEncoder(w).Encode(certificate); err != nil {
+		log.Printf("error encoding certificate: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/tlscert/backend/internal/manager"
 	"net/http"
+
+	"github.com/tlscert/backend/internal/manager"
 )
 
 type Server struct {

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -2,10 +2,11 @@ package kubernetes
 
 import (
 	"errors"
+	"os"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
 
 	certmanagerclientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 )

--- a/internal/manager/certificate.go
+++ b/internal/manager/certificate.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"errors"
+
 	"github.com/tlscert/backend/internal"
 	"github.com/tlscert/backend/internal/kubernetes"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+buf = "latest"
+go = "latest"
+golangci-lint = "latest"
+protobuf = "latest"


### PR DESCRIPTION
I've not added any CI stuff here yet, but for now we can remember to run `golangci-lint run` locally.